### PR TITLE
fix: apply PHP 8.1 change to the strpos method

### DIFF
--- a/view/frontend/templates/product/list.phtml
+++ b/view/frontend/templates/product/list.phtml
@@ -114,7 +114,7 @@ $_helper = $block->getData('outputHelper');
                                             <?php endif; ?>
                                         <?php endif; ?>
                                     </div>
-                                    <?= strpos($pos, $viewMode . '-primary') ?
+                                    <?= $pos != null && strpos($pos, $viewMode . '-primary') ?
                                         /* @noEscape */ $secureRenderer->renderStyleAsTag(
                                             $position,
                                             'product-item-info_' . $_product->getId() . ' div.actions-primary'
@@ -124,7 +124,7 @@ $_helper = $block->getData('outputHelper');
                                             <?= $addToBlock->setProduct($_product)->getChildHtml() ?>
                                         <?php endif; ?>
                                     </div>
-                                    <?= strpos($pos, $viewMode . '-secondary') ?
+                                    <?= $pos != null && strpos($pos, $viewMode . '-secondary') ?
                                         /* @noEscape */ $secureRenderer->renderStyleAsTag(
                                             $position,
                                             'product-item-info_' . $_product->getId() . ' div.actions-secondary'
@@ -145,7 +145,7 @@ $_helper = $block->getData('outputHelper');
                             </div>
                         </div>
                     </div>
-                    <?= strpos($pos, $viewMode . '-actions') ?
+                    <?= $pos != null && strpos($pos, $viewMode . '-actions') ?
                         /* @noEscape */ $secureRenderer->renderStyleAsTag(
                             $position,
                             'product-item-info_' . $_product->getId() . ' div.product-item-actions'


### PR DESCRIPTION
The strpos method allows the first argument as null and returns null on previous PHP versions, but raises an exception on PHP 8.1 used on Magento 2.4.4.

Due to this issue, the category products view shows no products.

This change handles this null value before calling the strpos method to fix this issue.


<!-- MANDATORY DATA -->
The following sections are required to be completed before merging your PR. It ensures we are following our release process and meeting our auditability requirements. PLEASE ADD MORE CONTEXT WHERE APPLICABLE. If you would like to learn more have a read of https://app.tettra.co/teams/marketplacer/pages/system-acquisition-and-development-policy and https://app.tettra.co/teams/marketplacer/pages/threat-modelling


**Release Checklist:**
<!-- tick the box to show you thought about it, but give more info if you made changes. -->
- [x] Authentication is on point (you are who you say you are)
- [x] Authorisation is on point (you are allowed to access this)
- [x] Data and input/output validation controls (SQL injection, XSS attacks, file validation, type conversion)
- [x] Error and exception handling controls (transaction rollbacks, parsing external errors)
- [x] Any newly introduced PII or confidential data is appropriately handled.  This includes external systems like Rollbar and Datadog, but also applies internally to Dupliplacer, Umbrella_Placer and the like.
- [x] Any schema changes have been notified to the data platform team in #data-change-notifications on slack.
- [x] Aware of the downstream/upstream effects this change will have. The Marketplacer ecosystem is beyond complicated and now has many system dependencies.  Take the time to understand how your change interacts with them and speak to some teams if you need to (MConnect, Cerberus, Graphql, API V2, Headless, Connected, Fullstack, Minsights, Umbrella_Placer, Spreadsheet Uploaders, MStores, MultiStores, and more!)
- [x] Supporting documentation published. A release is not just pushing a code change, it's also communicating it.
In-App documentation, Knowledgebase, API Docs, Tettra Docs, Postman Collection, Lucid Charts, and your PM knows what's up.

Resolves https://github.com/marketplacer/cerberus/issues/1928
